### PR TITLE
fix(client): add additional attribute check in order to work in Salesforces Locker env

### DIFF
--- a/lib/client/utilities.js
+++ b/lib/client/utilities.js
@@ -30,15 +30,29 @@ function getCaseSensitiveTagName(tagName) {
  * Formats DOM attributes to a hash map.
  *
  * @param {NamedNodeMap} attributes - List of attributes.
+ * @param {Node} node - DOM node of attributes.
  * @returns {object} - Map of attribute name to value.
  */
-function formatAttributes(attributes) {
+function formatAttributes(attributes, node) {
   var result = {};
   var attribute;
   // `NamedNodeMap` is array-like
   for (var i = 0, len = attributes.length; i < len; i++) {
     attribute = attributes[i];
     result[attribute.name] = attribute.value;
+  }
+  // In Salesforce's Locker env, there is a issue that `node.attributes` does not stably return correct collection for a/img tags,
+  // so we need to check the known attributes explicitly.
+  var lowerTagName = node && node.tagName.toLowerCase();
+  if (lowerTagName === 'a' || lowerTagName === 'img') {
+    var attrNames = ['src', 'href', 'alt', 'title'];
+    for (var j = 0; j < attrNames.length; j++) {
+      var attrName = attrNames[j];
+      var attrValue = node.getAttribute(attrName);
+      if (attrValue != null) {
+        result[attrName] = attrValue;
+      }
+    }
   }
   return result;
 }
@@ -81,7 +95,7 @@ function formatDOM(nodes, parent, directive) {
       case 1:
         tagName = formatTagName(node.nodeName);
         // script, style, or tag
-        current = new Element(tagName, formatAttributes(node.attributes));
+        current = new Element(tagName, formatAttributes(node.attributes, node));
         current.children = formatDOM(
           // template children are on content
           tagName === 'template' ? node.content.childNodes : node.childNodes,


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?
Work this lib properly in Salesforce's Locker env.

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?
In Salesforce's Locker env, the node attributes becomes empty or not stably returns correct values for anchor tag / image tag.

<!-- Please link to the issue (if applicable). -->

## What is the new behavior?
Additionally check the attributes by name for anchor/image tags, not trusting the `node.attributes` result.

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Types
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
